### PR TITLE
Fix for the header comments on each python file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+FlyYeastModel
+
+A project by Anya Vostinar et al.
+
+Code repository started on the 22nd of May, 2015.

--- a/fly.py
+++ b/fly.py
@@ -1,8 +1,6 @@
-############
-#A class library to model fly behavior.
-#Anya Vostinar
-#5/22/15
-############
+"""
+A class library to model fly behavior.
+"""
 
 class Fly(object):
     '''Doc string'''

--- a/license.txt
+++ b/license.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Anya Vostinar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/world.py
+++ b/world.py
@@ -9,9 +9,9 @@ NUM_FLY = 10
 NUM_YEAST_COL = 10
 NUM_UPDATES = 100
 
-fly_pop = [Fly() for _ in range(NUM_FLY)]
+FLY_POP = [Fly() for _ in range(NUM_FLY)]
 
-yeast_pop = [Yeast() for _ in range(NUM_YEAST_COL)]
+FREE_YEAST_POP = [Yeast() for _ in range(NUM_YEAST_COL)]
 
 def update():
     #loop through yeast and let them try to sporulate or grow

--- a/world.py
+++ b/world.py
@@ -5,16 +5,13 @@ A representation of the world for a fly and yeast simulation.
 from fly import Fly
 from yeast import Yeast
 
-num_fly = 10
-num_yeast_col = 10
+NUM_FLY = 10
+NUM_YEAST_COL = 10
+NUM_UPDATES = 100
 
-fly_pop = []
-for i in range(num_fly):
-    fly_pop.append(Fly())
+fly_pop = [Fly() for _ in range(NUM_FLY)]
 
-yeast_pop = []
-fori in range(num_yeast_col):
-    yeast_pop.append(Yeast())
+yeast_pop = [Yeast() for _ in range(NUM_YEAST_COL)]
 
 def update():
     #loop through yeast and let them try to sporulate or grow
@@ -26,5 +23,5 @@ def update():
     #if fly already had spores in it and lands in patch with room, spores hatch to yeast in that patch
     pass
 
-for i in range(100):
+for i in range(NUM_UPDATES):
     update()

--- a/world.py
+++ b/world.py
@@ -1,8 +1,6 @@
-###########
-#A representation of the world for a fly and yeast simulation.
-#Anya Vostinar
-#5/22/15
-###########
+"""
+A representation of the world for a fly and yeast simulation.
+"""
 
 from fly import Fly
 from yeast import Yeast
@@ -15,7 +13,7 @@ for i in range(num_fly):
     fly_pop.append(Fly())
 
 yeast_pop = []
-for i in range(num_yeast_col):
+fori in range(num_yeast_col):
     yeast_pop.append(Yeast())
 
 def update():

--- a/yeast.py
+++ b/yeast.py
@@ -1,8 +1,6 @@
-###########
-#A class library to represent yeast in a mutualism model.
-#Anya Vostinar
-#5/22/15
-###########
+"""
+A class library to represent yeast in a mutualism model.
+"""
 
 class Yeast(object):
     def __init__(self):

--- a/yeast.py
+++ b/yeast.py
@@ -2,14 +2,22 @@
 A class library to represent yeast in a mutualism model.
 """
 
+import random
+
 class Yeast(object):
     def __init__(self):
         #Sporulation efficiency is how quickly and what percentage of yeast sporulate/are more prone to sporulation and therefore are more likely to be picked up by a fly but have slower vegetative growth
         self.spore_prob = .5
+        self.is_spore = False
 
     def update(self):
-        
-        #check if sporulate
-        #if didn't sporulate, try to grow
-        #if did sporulate, chill out
+        if self.is_spore:
+            #Do nothing
+            return
+        if random.random() < self.spore_prob:
+            #Sporulate
+            self.is_spore = True
+            return
+        #Grow
         pass
+


### PR DESCRIPTION
As discussed via email, module level docstrings are better than comments. Dates and authors shouldn't be in each file.
